### PR TITLE
HADDR must always be sampled on the address phase

### DIFF
--- a/src/ahb_lite_uart16550.v
+++ b/src/ahb_lite_uart16550.v
@@ -97,7 +97,7 @@ module ahb_lite_uart16550(
         //io
         case(State)
             default     :   conf = { 2'b00, 8'b0     };
-            S_READ      :   conf = { 2'b10, ADDR     };
+            S_READ      :   conf = { 2'b10, ADDR_old };
             S_WRITE     :   conf = { 2'b01, ADDR_old };
         endcase
     end


### PR DESCRIPTION
According to AMBA AHB Protocol Specification, slaves "must be capable of sampling the address during this time" (1.3 Operation).

Since master is not obliged to keep nor to drop HADDR signals during the data phase, different implementations behave differently.

This patch fixes reading from UART for our AHB master.